### PR TITLE
Wall and pen support

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1,3 +1,7 @@
 {
-  "TOUCHVTT.Erase": "Erase"
+  "TOUCHVTT.Erase": "Erase",
+  "TOUCHVTT.ToggleWallChain": "Toggle Wall Chaining",
+  "TOUCHVTT.UndoWall": "Undo Last Wall",
+  "TOUCHVTT.DeleteWall": "Delete Selected Wall",
+  "TOUCHVTT.BigButton": "Make tool buttons bigger"
 }

--- a/src/logic/CanvasTouchToMouseAdapter.js
+++ b/src/logic/CanvasTouchToMouseAdapter.js
@@ -13,17 +13,19 @@ class CanvasTouchToMouseAdapter extends TouchToMouseAdapter {
   handleTouchMove(event) {
     this.updateActiveTouches(event)
 
-    if (event.touches.length === 2 && Object.keys(this.touches).length === 2) {
+    if ( Object.keys(this.touches).length === 2) {
       // Two-finger touch move
       this.handleTwoFingerGesture(event)
     }
-
-    this.forwardTouches(event)
+    else {
+      this.forwardTouches(event, Object.values(this.touches))
+    }
   }
 
   handleTwoFingerGesture(event) {
-    const firstTouch = this.touches[event.touches[0].identifier]
-    const secondTouch = this.touches[event.touches[1].identifier]
+    const k = Object.keys(this.touches)
+    const firstTouch = this.touches[k[0]]
+    const secondTouch = this.touches[k[1]]
 
     const zoomBefore = FoundryCanvas.worldTransform.a
     const zoomAfter = this.calcZoom(firstTouch, secondTouch)
@@ -68,9 +70,9 @@ class CanvasTouchToMouseAdapter extends TouchToMouseAdapter {
     return {
       // First simulate that the pointer moves to the specified location, then simulate the down event.
       // Foundry won't take the "click" on the first try otherwise.
-      touchstart: ['pointermove', 'pointerdown'],
-      touchmove: ['pointermove'],
-      touchend: ['pointerup'],
+      pointerdown: ['pointermove', 'pointerdown'],
+      pointermove: ['pointermove'],
+      pointerup: ['pointerup'],
     }
   }
 

--- a/src/logic/CanvasTouchToMouseAdapter.js
+++ b/src/logic/CanvasTouchToMouseAdapter.js
@@ -66,16 +66,6 @@ class CanvasTouchToMouseAdapter extends TouchToMouseAdapter {
     return Vectors.subtract(touchedPointOnWorldAfter, touch.world)
   }
 
-  getEventMap() {
-    return {
-      // First simulate that the pointer moves to the specified location, then simulate the down event.
-      // Foundry won't take the "click" on the first try otherwise.
-      pointerdown: ['pointermove', 'pointerdown'],
-      pointermove: ['pointermove'],
-      pointerup: ['pointerup'],
-    }
-  }
-
   getTouchContextByTouches(touches) {
     return touches.length >= 2 ? TouchContext.ZOOM_PAN_GESTURE : TouchContext.PRIMARY_CLICK
   }

--- a/src/logic/CanvasTouchToMouseAdapter.js
+++ b/src/logic/CanvasTouchToMouseAdapter.js
@@ -16,16 +16,16 @@ class CanvasTouchToMouseAdapter extends TouchToMouseAdapter {
     if ( Object.keys(this.touches).length === 2) {
       // Two-finger touch move
       this.handleTwoFingerGesture(event)
-    }
-    else {
+    } else {
       this.forwardTouches(event, Object.values(this.touches))
     }
   }
 
   handleTwoFingerGesture(event) {
-    const k = Object.keys(this.touches)
-    const firstTouch = this.touches[k[0]]
-    const secondTouch = this.touches[k[1]]
+    // Use the first two touch points for gestures
+    const touchIds = Object.keys(this.touches)
+    const firstTouch = this.touches[touchIds[0]]
+    const secondTouch = this.touches[touchIds[1]]
 
     const zoomBefore = FoundryCanvas.worldTransform.a
     const zoomAfter = this.calcZoom(firstTouch, secondTouch)

--- a/src/logic/FakeTouchEvent.js
+++ b/src/logic/FakeTouchEvent.js
@@ -77,15 +77,12 @@ function trackActivePointers(type, touch, mouseButton) {
   }
 }
 
-export function fakeTouchEvent(originalEvent, touch, mouseButton, eventMap, target = null) {
+export function fakeTouchEvent(originalEvent, touch, mouseButton, target = null) {
   if (originalEvent == null || typeof originalEvent !== 'object') {
     console.warn(`Passed invalid event argument to fakeTouchEvent: ${originalEvent}`)
     return
   }
 
-  const types = eventMap[originalEvent.type]
-
-  for (const type of types) {
-    dispatchFakeEvent(originalEvent, touch, mouseButton, type, target || touch.target)
-  }
+  dispatchFakeEvent(originalEvent, touch, mouseButton, originalEvent.type, target || touch.target)
+  
 }

--- a/src/logic/FakeTouchEvent.js
+++ b/src/logic/FakeTouchEvent.js
@@ -17,8 +17,8 @@ function bitCodeMouseButton(button) {
 
 export function dispatchFakeEvent(originalEvent, touch, mouseButton, type, target = touch.target) {
   const mouseEventInitProperties = {
-    clientX: touch.current?touch.current.x:touch.clientX,
-    clientY: touch.current?touch.current.y:touch.clientY,
+    clientX: touch.current ? touch.current.x : touch.clientX,
+    clientY: touch.current ? touch.current.y : touch.clientY,
     screenX: touch.screenX,
     screenY: touch.screenY,
     ctrlKey: originalEvent.ctrlKey || false,
@@ -44,7 +44,7 @@ export function dispatchFakeEvent(originalEvent, touch, mouseButton, type, targe
     simulatedEvent = new MouseEvent(type, mouseEventInitProperties)
   } else {
     const pointerEventInit = {
-      pointerId: touch.pointerId,
+      pointerId: touch.identifier,
       pointerType: 'mouse',
       isPrimary: true,
       ...mouseEventInitProperties,
@@ -61,15 +61,15 @@ export function dispatchFakeEvent(originalEvent, touch, mouseButton, type, targe
 let activePointers = []
 function trackActivePointers(type, touch, mouseButton) {
   if (type === 'pointerdown') {
-    activePointers.push({ id: touch.pointerId, type, mouseButton })
+    activePointers.push({ id: touch.identifier, type, mouseButton })
   } else if (type === 'pointerup') {
-    const index = activePointers.findIndex(e => e.id === touch.pointerId && e.mouseButton === mouseButton)
+    const index = activePointers.findIndex(e => e.id === touch.identifier && e.mouseButton === mouseButton)
     if (index !== -1) {
       activePointers.splice(index, 1)
     }
   }
   if (type === 'pointerdown' || type === 'pointerup') {
-    console.log(`${type} ${touch.pointerId}, button ${mouseButton}`)
+    console.log(`${type} ${touch.identifier}, button ${mouseButton}`)
     console.log(`Active pointers: ${activePointers.length}`)
     for (const ap of activePointers) {
       console.log(`\tID: ${ap.id}, Button: ${ap.mouseButton}`)

--- a/src/logic/FakeTouchEvent.js
+++ b/src/logic/FakeTouchEvent.js
@@ -17,8 +17,8 @@ function bitCodeMouseButton(button) {
 
 export function dispatchFakeEvent(originalEvent, touch, mouseButton, type, target = touch.target) {
   const mouseEventInitProperties = {
-    clientX: touch.clientX,
-    clientY: touch.clientY,
+    clientX: touch.current?touch.current.x:touch.clientX,
+    clientY: touch.current?touch.current.y:touch.clientY,
     screenX: touch.screenX,
     screenY: touch.screenY,
     ctrlKey: originalEvent.ctrlKey || false,
@@ -44,7 +44,7 @@ export function dispatchFakeEvent(originalEvent, touch, mouseButton, type, targe
     simulatedEvent = new MouseEvent(type, mouseEventInitProperties)
   } else {
     const pointerEventInit = {
-      pointerId: touch.identifier,
+      pointerId: touch.pointerId,
       pointerType: 'mouse',
       isPrimary: true,
       ...mouseEventInitProperties,
@@ -53,6 +53,7 @@ export function dispatchFakeEvent(originalEvent, touch, mouseButton, type, targe
   }
 
   // trackActivePointers(type, touch, mouseButton)
+  //console.log("Sim",simulatedEvent.clientX, simulatedEvent.clientY,simulatedEvent.type,originalEvent)//,touch)
 
   target.dispatchEvent(simulatedEvent)
 }
@@ -60,15 +61,15 @@ export function dispatchFakeEvent(originalEvent, touch, mouseButton, type, targe
 let activePointers = []
 function trackActivePointers(type, touch, mouseButton) {
   if (type === 'pointerdown') {
-    activePointers.push({ id: touch.identifier, type, mouseButton })
+    activePointers.push({ id: touch.pointerId, type, mouseButton })
   } else if (type === 'pointerup') {
-    const index = activePointers.findIndex(e => e.id === touch.identifier && e.mouseButton === mouseButton)
+    const index = activePointers.findIndex(e => e.id === touch.pointerId && e.mouseButton === mouseButton)
     if (index !== -1) {
       activePointers.splice(index, 1)
     }
   }
   if (type === 'pointerdown' || type === 'pointerup') {
-    console.log(`${type} ${touch.identifier}, button ${mouseButton}`)
+    console.log(`${type} ${touch.pointerId}, button ${mouseButton}`)
     console.log(`Active pointers: ${activePointers.length}`)
     for (const ap of activePointers) {
       console.log(`\tID: ${ap.id}, Button: ${ap.mouseButton}`)

--- a/src/logic/Touch.js
+++ b/src/logic/Touch.js
@@ -51,10 +51,10 @@ class Touch {
       return
     }
     if (this.context !== newContext) {
-      if (this.context.forwardsEvent('touchend')) {
+      if (this.context.forwardsEvent('pointerup')) {
         dispatchFakeEvent(this.latestEvent, this, this.context.mouseButton, 'pointerup')
       }
-      if (newContext.forwardsEvent('touchstart')) {
+      if (newContext.forwardsEvent('pointerdown')) {
         dispatchFakeEvent(this.latestEvent, this, newContext.mouseButton, 'pointerdown')
       }
     }

--- a/src/logic/Touch.js
+++ b/src/logic/Touch.js
@@ -5,7 +5,7 @@ import {dispatchFakeEvent} from './FakeTouchEvent.js'
 
 class Touch {
   constructor(event, { context = TouchContext.PRIMARY_CLICK } = {}) {
-    this.pointerId = event.pointerId
+    this.identifier = event.pointerId
     this.start = Object.freeze({ x: event.clientX, y: event.clientY })
     this.last = this.start
     this.current = this.last
@@ -33,7 +33,7 @@ class Touch {
   }
 
   get identifier() {
-    return this.pointerId
+    return this.identifier
   }
 
   update(event) {

--- a/src/logic/Touch.js
+++ b/src/logic/Touch.js
@@ -4,23 +4,24 @@ import Vectors from './Vectors.js'
 import {dispatchFakeEvent} from './FakeTouchEvent.js'
 
 class Touch {
-  constructor(event, touchSource, { context = TouchContext.PRIMARY_CLICK } = {}) {
-    this.id = touchSource.identifier
-    this.start = Object.freeze({ x: touchSource.clientX, y: touchSource.clientY })
+  constructor(event, { context = TouchContext.PRIMARY_CLICK } = {}) {
+    this.pointerId = event.pointerId
+    this.start = Object.freeze({ x: event.clientX, y: event.clientY })
     this.last = this.start
     this.current = this.last
     this.context = context
-    this.clientX = touchSource.clientX
-    this.clientY = touchSource.clientY
-    this.screenX = touchSource.screenX
-    this.screenY = touchSource.screenY
-    this.target = touchSource.target
+    this.clientX = event.clientX
+    this.clientY = event.clientY
+    this.screenX = event.screenX
+    this.screenY = event.screenY
+    this.target = event.target
     this.latestEvent = event
 
     this.world = FoundryCanvas.screenToWorld(this.current)  //< Position in the world where the user touched
     this.movementDistance = 0
     this.movement = Vectors.zero
 
+    //console.log("Construct",this.current)
     this.longPressTimeout = setTimeout(() => {
       // Long click detection: if the pointer hasn't moved considerably and if this is still the only touch point,
       // then we need to treat this as a right-click.
@@ -32,13 +33,13 @@ class Touch {
   }
 
   get identifier() {
-    return this.id
+    return this.pointerId
   }
 
-  update(event, touchSource) {
+  update(event) {
     this.latestEvent = event
     this.last = this.current
-    this.current = Object.freeze({ x: touchSource.clientX, y: touchSource.clientY })
+    this.current = Object.freeze({ x: event.clientX, y: event.clientY })
     this.movementDistance += Vectors.distance(this.last, this.current)
     this.movement = Vectors.add(this.movement, Vectors.subtract(this.current, this.last))
   }

--- a/src/logic/Touch.js
+++ b/src/logic/Touch.js
@@ -5,7 +5,7 @@ import {dispatchFakeEvent} from './FakeTouchEvent.js'
 
 class Touch {
   constructor(event, { context = TouchContext.PRIMARY_CLICK } = {}) {
-    this.identifier = event.pointerId
+    this.id = event.pointerId
     this.start = Object.freeze({ x: event.clientX, y: event.clientY })
     this.last = this.start
     this.current = this.last
@@ -33,7 +33,7 @@ class Touch {
   }
 
   get identifier() {
-    return this.identifier
+    return this.id
   }
 
   update(event) {

--- a/src/logic/TouchContext.js
+++ b/src/logic/TouchContext.js
@@ -19,13 +19,13 @@ class TouchContext {
 
 const PRIMARY_CLICK = Object.freeze(new TouchContext({
   name: 'primary-click',
-  forwardingEvents: ['touchstart', 'touchmove', 'touchend', 'touchcancel'],
+  forwardingEvents: ['pointerdown', 'pointermove', 'pointerup', 'pointercancel'],
   mouseButton: MouseButton.left,
   isFinal: false,
 }))
 const SECONDARY_CLICK = Object.freeze(new TouchContext({
   name: 'secondary-click',
-  forwardingEvents: ['touchstart', 'touchmove', 'touchend', 'touchcancel'],
+  forwardingEvents: ['pointerdown', 'pointermove', 'pointerup', 'pointercancel'],
   mouseButton: MouseButton.right,
 }))
 const ZOOM_PAN_GESTURE = Object.freeze(new TouchContext({

--- a/src/logic/TouchToMouseAdapter.js
+++ b/src/logic/TouchToMouseAdapter.js
@@ -72,13 +72,13 @@ class TouchToMouseAdapter {
   forwardTouches(event, touches) {
 
     for (const touch of Object.values(this.touches)) {
-      const touchInstance = this.getTouch(touch.pointerId)
+      const touchInstance = this.getTouch(touch.identifier)
       if (touchInstance != null) {
         if (touchInstance.context.forwardsEvent(event)) {
           fakeTouchEvent(event, touch, touchInstance.context.mouseButton, this.getEventTarget(event))
         }
       } else {
-        console.warn(`Found no touch instance for ID ${touch.pointerId}`, this.touches)
+        console.warn(`Found no touch instance for ID ${touch.identifier}`, this.touches)
       }
     }
   }

--- a/src/logic/TouchToMouseAdapter.js
+++ b/src/logic/TouchToMouseAdapter.js
@@ -75,7 +75,7 @@ class TouchToMouseAdapter {
       const touchInstance = this.getTouch(touch.pointerId)
       if (touchInstance != null) {
         if (touchInstance.context.forwardsEvent(event)) {
-          fakeTouchEvent(event, touch, touchInstance.context.mouseButton, this.getEventMap(), this.getEventTarget(event))
+          fakeTouchEvent(event, touch, touchInstance.context.mouseButton, this.getEventTarget(event))
         }
       } else {
         console.warn(`Found no touch instance for ID ${touch.pointerId}`, this.touches)
@@ -114,13 +114,6 @@ class TouchToMouseAdapter {
     }
   }
 
-  getEventMap() {
-    return {
-      pointerdown: ['pointerdown'],
-      pointermove: ['pointermove'],
-      pointerup: ['pointerup'],
-    }
-  }
 
   getEventTarget() {
     return null // pick the same target as the original event

--- a/src/logic/WindowHeaderTouchToMouseAdapter.js
+++ b/src/logic/WindowHeaderTouchToMouseAdapter.js
@@ -8,7 +8,7 @@ class WindowHeaderTouchToMouseAdapter extends TouchToMouseAdapter {
   }
 
   getEventTarget(event) {
-    if (event.type === 'touchstart') {
+    if (event.type === 'pointerdown') {
       return this.getParentByClass(event.target, 'window-header')
     } else {
       return window
@@ -16,13 +16,13 @@ class WindowHeaderTouchToMouseAdapter extends TouchToMouseAdapter {
   }
 
   shouldHandleEvent(event) {
-    if (event.type === 'touchstart') {
+    if (event.type === 'pointerdown') {
       const inWindowTitle = this.isInWindowTitle(event.target)
       if (inWindowTitle) {
         this.dragging = true
       }
       return inWindowTitle
-    } else if (this.dragging && event.type === 'touchend') {
+    } else if (this.dragging && event.type === 'pointerup') {
       this.dragging = false
       return true
     } else {

--- a/src/tools/WallTools.js
+++ b/src/tools/WallTools.js
@@ -1,8 +1,47 @@
 import {injectMethodCondition, replaceMethod} from '../utils/Injection.js'
+import {MODULE_NAME} from '../config/ModuleConstants.js'
 
-Hooks.once("init", registerSettings)
+const STYLE_ID = `${MODULE_NAME}-bug_button_styles`
+const big_button_style =  `
+#controls .scene-control, #controls .control-tool {
+    width: 50px;
+    height: 50px;
+    line-height: 50px;
+    font-size: 28px;
+}
+#controls .control-tools {
+    left: 72px;
+}
+`
+
+let button_size = false
+Hooks.once("init", () => {
+    createStyleElement();
+    registerSettings();
+})   
 
 Hooks.on("getSceneControlButtons", addControls)
+
+
+function createStyleElement() {
+    const style = document.createElement('style')
+    style.setAttribute('id', STYLE_ID)
+    document.head.append(style)
+    return style
+}
+
+function updateButtonSize(button_size) {
+    const style = document.getElementById(STYLE_ID)
+    if (style != null) {
+        if (button_size){
+            style.innerText = big_button_style
+        } else {
+            style.innerText = ''
+        }
+    }
+}
+  
+
 
 function registerSettings() { // Monkey patch click function to force this._chain when chainmode is set
 
@@ -53,13 +92,9 @@ function addControls(menuStructure) {
         title: "TOUCHVTT.BigButton",
         icon: "fas fa-expand-alt",
         visible: true,
-        button: true,
-        onClick: () => {
-            window.document.styleSheets[0].insertRule("#controls .control-tool, #controls .scene-control {width: 59px;height: 59px; font-size: 48px;line-height: revert;}", window.document.styleSheets[0].rules.length)
-            window.document.styleSheets[0].insertRule("#controls .control-tools {left: 78px}", window.document.styleSheets[0].rules.length)
-        }
+        toggle: true,
+        active: button_size,
+        onClick: toggled => {updateButtonSize(toggled)}
     })
-
-
 }
 

--- a/src/tools/WallTools.js
+++ b/src/tools/WallTools.js
@@ -13,8 +13,11 @@ const big_button_style =  `
     left: 72px;
 }
 `
-
+// Local storage for GUI toggles, since they shouldn't be saved over reloads
+let chainmode = false
 let button_size = false
+
+
 Hooks.once("init", () => {
     createStyleElement();
     registerSettings();
@@ -47,18 +50,10 @@ function registerSettings() { // Monkey patch click function to force this._chai
 
     replaceMethod(WallsLayer.prototype, '_onClickLeft', ({callOriginal, self}) => {
         callOriginal()
-        if (game.settings.get("touch-vtt", "CHAIN_WALLS")) {
+        if (chainmode) {
             self._chain = true
         }
     })
-
-    // Register setting to track controls toggle setting
-    game.settings.register('touch-vtt', "CHAIN_WALLS", {
-        scope: "world",
-        type: Boolean,
-        default: false,
-        config: false
-    });
 }
 
 function addControls(menuStructure) {
@@ -70,8 +65,8 @@ function addControls(menuStructure) {
         title: "TOUCHVTT.ToggleWallChain",
         icon: "fas fa-link",
         toggle: true,
-        active: game.settings.get("touch-vtt", "CHAIN_WALLS"),
-        onClick: toggled => game.settings.set("touch-vtt", "CHAIN_WALLS", toggled)
+        active: chainmode,
+        onClick: toggled => chainmode =  toggled
     }, {
         // Simulates hitting Ctrl-Z
         name: "undo",

--- a/src/tools/wall-tools.js
+++ b/src/tools/wall-tools.js
@@ -1,0 +1,65 @@
+import {injectMethodCondition, replaceMethod} from '../utils/Injection.js'
+
+Hooks.once("init", registerSettings)
+
+Hooks.on("getSceneControlButtons", addControls)
+
+function registerSettings() { // Monkey patch click function to force this._chain when chainmode is set
+
+    replaceMethod(WallsLayer.prototype, '_onClickLeft', ({callOriginal, self}) => {
+        callOriginal()
+        if (game.settings.get("touch-vtt", "CHAIN_WALLS")) {
+            self._chain = true
+        }
+    })
+
+    // Register setting to track controls toggle setting
+    game.settings.register('touch-vtt', "CHAIN_WALLS", {
+        scope: "world",
+        type: Boolean,
+        default: false,
+        config: false
+    });
+}
+
+function addControls(menuStructure) {
+    const wallCategory = menuStructure.find(c => c.name === 'walls')
+
+    wallCategory.tools.push({
+        // Simulates holding ctrl while drawing walls
+        name: "tile",
+        title: "TOUCHVTT.ToggleWallChain",
+        icon: "fas fa-link",
+        toggle: true,
+        active: game.settings.get("touch-vtt", "CHAIN_WALLS"),
+        onClick: toggled => game.settings.set("touch-vtt", "CHAIN_WALLS", toggled)
+    }, {
+        // Simulates hitting Ctrl-Z
+        name: "undo",
+        title: "TOUCHVTT.UndoWall",
+        icon: "fas fa-undo",
+        button: true,
+        onClick: () => canvas.getLayer("WallsLayer").undoHistory()
+    }, {
+        // Simulate hitting del with a wall selected
+        name: "Delete",
+        title: "TOUCHVTT.DeleteWall",
+        icon: "fas fa-eraser",
+        button: true,
+        onClick: () => canvas.getLayer("WallsLayer")._onDeleteKey()
+    }, {
+        // This likely needs to move someplace else, but it's a useful touchscreen feature.
+        name: "big",
+        title: "TOUCHVTT.BigButton",
+        icon: "fas fa-expand-alt",
+        visible: true,
+        button: true,
+        onClick: () => {
+            window.document.styleSheets[0].insertRule("#controls .control-tool, #controls .scene-control {width: 59px;height: 59px; font-size: 48px;line-height: revert;}", window.document.styleSheets[0].rules.length)
+            window.document.styleSheets[0].insertRule("#controls .control-tools {left: 78px}", window.document.styleSheets[0].rules.length)
+        }
+    })
+
+
+}
+

--- a/src/touch-vtt.js
+++ b/src/touch-vtt.js
@@ -3,7 +3,7 @@ import CanvasTouchToMouseAdapter from './logic/CanvasTouchToMouseAdapter.js'
 import WindowHeaderTouchToMouseAdapter from './logic/WindowHeaderTouchToMouseAdapter.js'
 
 import '../style/touch-vtt.css'
-import '../src/tools/wall-tools.js'
+import '../src/tools/WallTools.js'
 import {injectMethodCondition, replaceMethod} from './utils/Injection.js'
 import {installMeasurementTemplateEraser} from './tools/MeasurementTemplateEraser.js'
 

--- a/src/touch-vtt.js
+++ b/src/touch-vtt.js
@@ -3,6 +3,7 @@ import CanvasTouchToMouseAdapter from './logic/CanvasTouchToMouseAdapter.js'
 import WindowHeaderTouchToMouseAdapter from './logic/WindowHeaderTouchToMouseAdapter.js'
 
 import '../style/touch-vtt.css'
+import '../src/tools/wall-tools.js'
 import {injectMethodCondition, replaceMethod} from './utils/Injection.js'
 import {installMeasurementTemplateEraser} from './tools/MeasurementTemplateEraser.js'
 


### PR DESCRIPTION
This adds support for using a stylus in addition to the touch support.  For some background: stylus inputs worked in the stock version of foundry, since they seem to report both pointerdown and touchstart events.  For reasons that I still don't understand the touchevent interception touch-vtt was doing somehow broke that.  This PR changes to intercepting on pointer* events which are output by mouse,pen, and touch sources.  It then ignores any events that aren't touch based.  I've tested everything listed in the readme and they all seem to work: pinch zoom/pan, longpress(right click), and normal click/drag.

It addition, this adds a collection of touch friendly tools to the walls page:  
* Wall chaining (like holding ctrl normally)
* Undo
* Delete selected wall
* Enlarge Buttons

The latter probably doesn't belong on the walls, but as a global feature touch friendliness.  I just left it there as a proof of concept for your future use.

Please let me know if you have any questions about the changes I've made.  I'd be glad to work with you to resolve any issues I might have introduced.



