### PR TITLE
Ensure TouchEvent exists before using instanceof - fixes #16

### DIFF
--- a/src/logic/TouchToMouseAdapter.js
+++ b/src/logic/TouchToMouseAdapter.js
@@ -156,7 +156,7 @@ class TouchToMouseAdapter {
   }
 
   isTouchEvent(event) {
-    return event.pointerType === "touch" || event instanceof TouchEvent
+    return event.pointerType === "touch" || (typeof TouchEvent === "function" && event instanceof TouchEvent)
   }
 }
 


### PR DESCRIPTION
On Firefox, the TouchEvent class doesn't exist unless touch is enabled, see #16. This fix ensures that the class exists before using `instanceof`.