### PR TITLE
You can now click on the Foundry logo to toggle full-screen.

### DIFF
--- a/src/touch-vtt.js
+++ b/src/touch-vtt.js
@@ -37,6 +37,37 @@ Hooks.once('init', () => {
   initEasyTarget()
 })
 
+function _logoClicked() {
+  var elem = $("body.vtt")[0];
+  var d = document;
+  var isFullScreen = (d.fullscreenElement && d.fullscreenElement !== null) || (d.mozFullScreenElement && d.mozFullScreenElement !== null) || (d.webkitFullscreenEnabled && d.webkitFullscreenElement !== null)
+      || (d.msFullscreenElement && d.msFullscreenElement !== null);
+  if (!isFullScreen) {
+      if (elem.requestFullScreen) {
+          elem.requestFullScreen();
+      } else if (elem.mozRequestFullScreen) {
+          elem.mozRequestFullScreen();
+      } else if (elem.webkitRequestFullScreen) {
+          elem.webkitRequestFullScreen(Element.ALLOW_KEYBOARD_INPUT);
+      } else if (elem.msRequestFullscreen) {
+          elem.msRequestFullscreen();
+      }
+  } else {
+      if (d.cancelFullScreen) {
+          d.cancelFullScreen();
+      } else if (d.mozCancelFullScreen) {
+          d.mozCancelFullScreen();
+      } else if (d.webkitCancelFullScreen) {
+          d.webkitCancelFullScreen();
+      } else if (d.msExitFullscreen) {
+          d.msExitFullscreen();
+      }
+  }
+}
+Hooks.on('ready', () => {
+  $("img#logo").click(_logoClicked);
+});
+
 Hooks.on('ready', function () {
   try {
     const canvas = findCanvas()


### PR DESCRIPTION
Hey! My apologies if I'm coming off a bit abrupt with this. 😄 

This PR lets the user touch the Foundry logo (in the top left corner) to toggle full screen mode for their browser. This provides more screen real estate, and it also deals with some annoying problems such as e.g. an Android system toolbar covering part of the GUI.

I've considered making this into its own module, but I think it'd be better if it was part of touch-vtt. While it technically should work on any platform, it's really only useful on touch devices. Keyboard devices usually already have an easy way to enter full screen, if supported.

I've tried to add this in an unobtrusive fashion. Feel free to modify however you see fit, or reject altogether, of course.